### PR TITLE
Add admin endpoint to indicate user refresh timestamp

### DIFF
--- a/kong-oidc-1.2.4-4.rockspec
+++ b/kong-oidc-1.2.4-4.rockspec
@@ -27,10 +27,11 @@ dependencies = {
 build = {
     type = "builtin",
     modules = {
-    ["kong.plugins.oidc.filter"] = "kong/plugins/oidc/filter.lua",
-    ["kong.plugins.oidc.handler"] = "kong/plugins/oidc/handler.lua",
-    ["kong.plugins.oidc.schema"] = "kong/plugins/oidc/schema.lua",
-    ["kong.plugins.oidc.session"] = "kong/plugins/oidc/session.lua",
-    ["kong.plugins.oidc.utils"] = "kong/plugins/oidc/utils.lua"
+        ["kong.plugins.oidc.api"] = "kong/plugins/oidc/api.lua",
+        ["kong.plugins.oidc.filter"] = "kong/plugins/oidc/filter.lua",
+        ["kong.plugins.oidc.handler"] = "kong/plugins/oidc/handler.lua",
+        ["kong.plugins.oidc.schema"] = "kong/plugins/oidc/schema.lua",
+        ["kong.plugins.oidc.session"] = "kong/plugins/oidc/session.lua",
+        ["kong.plugins.oidc.utils"] = "kong/plugins/oidc/utils.lua"
     }
 }

--- a/kong/plugins/oidc/api.lua
+++ b/kong/plugins/oidc/api.lua
@@ -1,31 +1,17 @@
 local typedefs = require "kong.db.schema.typedefs"
 
-local schema = {
-  name         = "user_refreshed",
-  workspaceable = true,
-
-  fields = {
-    { timestamp     = typedefs.auto_timestamp_s },
-  },
-}
-
 local shared = ngx.shared
 local store = shared['sessions']
 
 return {
-  ["/oidc/:user/refreshed"] = {
-    schema = schema,
-    methods = {
+  ["/oidc/refresh_user"] = {
+    GET = function(self)
+      return kong.response.exit(200, { timestamp = store["renewal_" .. self.params.user] })
+    end,
 
-      GET = function(self)
-        return { status = 200, json = { timestamp = store["renewal_" .. self.params.user] } }
-      end,
-
-      POST = function(self)
-        store["renewal_" .. self.params.user] = self.params.timestamp
-        return { status = 201, json = { success = true } }
-      end,
-
-    },
+    POST = function(self)
+      store["renewal_" .. self.params.user] = self.params.timestamp
+      return kong.response.exit(201, { success = true })
+    end,
   },
 }

--- a/kong/plugins/oidc/api.lua
+++ b/kong/plugins/oidc/api.lua
@@ -1,0 +1,31 @@
+local typedefs = require "kong.db.schema.typedefs"
+
+local schema = {
+  name         = "user_refreshed",
+  workspaceable = true,
+
+  fields = {
+    { timestamp     = typedefs.auto_timestamp_s },
+  },
+}
+
+local shared = ngx.shared
+local store = shared['oidc_user_refreshed']
+
+return {
+  ["/oidc/:user/refreshed"] = {
+    schema = schema,
+    methods = {
+
+      GET = function(self)
+        return { status = 200, json = { timestamp = store[self.params.user] } }
+      end,
+
+      POST = function(self)
+        store[self.params.user] = self.params.timestamp
+        return { status = 201, json = { success = true } }
+      end,
+
+    },
+  },
+}

--- a/kong/plugins/oidc/api.lua
+++ b/kong/plugins/oidc/api.lua
@@ -10,7 +10,7 @@ local schema = {
 }
 
 local shared = ngx.shared
-local store = shared['oidc_user_refreshed']
+local store = shared['sessions']
 
 return {
   ["/oidc/:user/refreshed"] = {
@@ -18,11 +18,11 @@ return {
     methods = {
 
       GET = function(self)
-        return { status = 200, json = { timestamp = store[self.params.user] } }
+        return { status = 200, json = { timestamp = store["renewal_" .. self.params.user] } }
       end,
 
       POST = function(self)
-        store[self.params.user] = self.params.timestamp
+        store["renewal_" .. self.params.user] = self.params.timestamp
         return { status = 201, json = { success = true } }
       end,
 

--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -130,12 +130,13 @@ function make_oidc(oidcConfig)
   local res, err = openidc.authenticate(oidcConfig, ngx.var.request_uri, unauth_action, session_opts)
 
   if not err and res then
-    ngx.log(ngx.ERR, "Checking renewal on token: " .. table_to_string(res.id_token))
+    local subject = res.id_token["sub"]
+    if subject then
+      local last_timestamp_modified = expiryStore["renewal_" .. subject]
 
-    local last_timestamp_modified = expiryStore["renewal_" .. res.id_token['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier']]
-
-    if last_timestamp_modified > res.id_token.iat then
-      res, err = openidc.force_renew(oidcConfig, session_opts)
+      if last_timestamp_modified and last_timestamp_modified > res.id_token.iat then
+        res, err = openidc.force_renew(oidcConfig, session_opts)
+      end
     end
   end
 

--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -130,11 +130,11 @@ function make_oidc(oidcConfig)
   local res, err = openidc.authenticate(oidcConfig, ngx.var.request_uri, unauth_action, session_opts)
 
   if not err and res then
-    ngx.log(ngx.ERROR, "Checking renewal on token: " .. table_to_string(res.access_token))
+    ngx.log(ngx.ERR, "Checking renewal on token: " .. table_to_string(res.id_token))
 
-    local last_timestamp_modified = expiryStore["renewal_" .. res.access_token['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier']]
+    local last_timestamp_modified = expiryStore["renewal_" .. res.id_token['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier']]
 
-    if last_timestamp_modified > res.access_token.iat then
+    if last_timestamp_modified > res.id_token.iat then
       res, err = openidc.force_renew(oidcConfig, session_opts)
     end
   end

--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -105,9 +105,9 @@ function make_oidc(oidcConfig)
   local res, err = openidc.authenticate(oidcConfig, ngx.var.request_uri, unauth_action, session_opts)
 
   if not err and res then
-    local last_timestamp_modified = expiryStore["renewal_" .. res.id_token['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier']]
+    local last_timestamp_modified = expiryStore["renewal_" .. res.access_token['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier']]
 
-    if last_timestamp_modified > res.id_token.iat then
+    if last_timestamp_modified > res.access_token.iat then
       res, err = openidc.force_renew(oidcConfig, session_opts)
     end
   end

--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -130,7 +130,7 @@ function make_oidc(oidcConfig)
   local res, err = openidc.authenticate(oidcConfig, ngx.var.request_uri, unauth_action, session_opts)
 
   if not err and res then
-    ngx.log(ngx.DEBUG, "Checking renewal on token: " .. table_to_string(res.access_token))
+    ngx.log(ngx.ERROR, "Checking renewal on token: " .. table_to_string(res.access_token))
 
     local last_timestamp_modified = expiryStore["renewal_" .. res.access_token['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier']]
 

--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -93,31 +93,6 @@ function handle(oidcConfig)
   end
 end
 
-local function table_to_string(tbl)
-  local result = "{"
-  for k, v in pairs(tbl) do
-      -- Check the key type (ignore any numerical keys - assume its an array)
-      if type(k) == "string" then
-          result = result.."[\""..k.."\"]".."="
-      end
-
-      -- Check the value type
-      if type(v) == "table" then
-          result = result..table_to_string(v)
-      elseif type(v) == "boolean" then
-          result = result..tostring(v)
-      else
-          result = result.."\""..v.."\""
-      end
-      result = result..","
-  end
-  -- Remove leading commas from the result
-  if result ~= "{" then
-      result = result:sub(1, result:len()-1)
-  end
-  return result.."}"
-end
-
 function make_oidc(oidcConfig)
   ngx.log(ngx.DEBUG, "OidcHandler calling authenticate, requested path: " .. ngx.var.request_uri)
   local unauth_action = oidcConfig.unauth_action
@@ -135,6 +110,7 @@ function make_oidc(oidcConfig)
       local last_timestamp_modified = expiryStore["renewal_" .. subject]
 
       if last_timestamp_modified and tonumber(last_timestamp_modified) > tonumber(res.id_token.iat) then
+    	  ngx.log(ngx.DEBUG, "Forced renewal of token for user: " .. subject)
         res, err = openidc.force_renew(oidcConfig, session_opts)
       end
     end

--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -134,7 +134,7 @@ function make_oidc(oidcConfig)
     if subject then
       local last_timestamp_modified = expiryStore["renewal_" .. subject]
 
-      if last_timestamp_modified and last_timestamp_modified > res.id_token.iat then
+      if last_timestamp_modified and tonumber(last_timestamp_modified) > tonumber(res.id_token.iat) then
         res, err = openidc.force_renew(oidcConfig, session_opts)
       end
     end

--- a/kong/plugins/oidc/handler.lua
+++ b/kong/plugins/oidc/handler.lua
@@ -5,7 +5,7 @@ local filter = require("kong.plugins.oidc.filter")
 local session = require("kong.plugins.oidc.session")
 
 local shared = ngx.shared
-local expiryStore = shared['oidc_user_refreshed']
+local expiryStore = shared['sessions']
 
 OidcHandler.PRIORITY = 1000
 
@@ -105,7 +105,7 @@ function make_oidc(oidcConfig)
   local res, err = openidc.authenticate(oidcConfig, ngx.var.request_uri, unauth_action, session_opts)
 
   if not err and res then
-    local last_timestamp_modified = expiryStore[res.id_token.id]
+    local last_timestamp_modified = expiryStore["renewal_" .. res.id_token['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier']]
 
     if last_timestamp_modified > res.id_token.iat then
       res, err = openidc.force_renew(oidcConfig, session_opts)

--- a/kong/plugins/oidc/schema.lua
+++ b/kong/plugins/oidc/schema.lua
@@ -40,5 +40,6 @@ return {
     bearer_jwt_auth_signing_algs = { type = "array", required = true, default = { "RS256" } },
     header_names = { type = "array", required = true, default = {} },
     header_claims = { type = "array", required = true, default = {} },
+    resty_session_storage = { type = "string", required = false, default = "cookie" },
   }
 }

--- a/kong/plugins/oidc/utils.lua
+++ b/kong/plugins/oidc/utils.lua
@@ -82,7 +82,8 @@ function M.get_options(config, ngx)
     bearer_jwt_auth_allowed_auds = config.bearer_jwt_auth_allowed_auds,
     bearer_jwt_auth_signing_algs = config.bearer_jwt_auth_signing_algs,
     header_names = config.header_names or {},
-    header_claims = config.header_claims or {}
+    header_claims = config.header_claims or {},
+    resty_session_storage = config.resty_session_storage,
   }
 end
 


### PR DESCRIPTION
Still a bit hacky. Uses the shm store used by resty.session.

For production use we should probably use redis or something distributed.